### PR TITLE
Add a projects folder that can safely be ignored in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .vagrant
+.DS_Store
+projects/*
+!projects/.keep


### PR DESCRIPTION
Cloning projects into the vagrant repo to work with inside and out of the VM makes it hard to make changes to the vagrant repo itself.  This creates a folder that can still be accessed inside and out of the VM, and not interfere with the changes going on to the vagrant file.

It also .DS_Store, to the ignore file.